### PR TITLE
[add]: house keeping with GitHub templates

### DIFF
--- a/.github/CODEOWNERS.txt
+++ b/.github/CODEOWNERS.txt
@@ -1,0 +1,2 @@
+# Default
+* @mirrorworld-universe/sonic-engineering

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,60 @@
+name: Bug Report
+description: Found a bug? Let us know!
+labels: ["bug"]
+assignees:
+  - kquirapas
+body:
+
+  # not existing bug block
+  - type: checkboxes
+    id: bug-confirm
+    attributes:
+      label: Not Existing Bug?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+      - label: Yes, I'm sure that this is a bug!
+        required: true
+
+  # current results block
+  - type: textarea
+    id: bug-current-behavior
+    attributes:
+      label: Current Behavior
+      description: A concise description of what you're experiencing.
+      placeholder: I see bugs flying around ewww... please help!
+    validations:
+      required: true
+
+  # expected behavior block
+  - type: textarea
+    id: bug-expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: A concise description of what you expected to happen.
+      placeholder: Bugs supposed to crawl not fly... peaceful life!
+    validations:
+      required: true
+
+  # steps to reproduce block
+  - type: textarea
+    id: bug-steps-to-reproduce
+    attributes:
+      label: Steps To Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. I go outside and see a bug.
+        2. The bug starts to crawl and fly, like wtf!
+        3. Run!!!
+        4. Bugs chasing me while flying!
+    validations:
+      required: false
+
+  # terms block
+  - type: checkboxes
+    id: bug-terms
+    attributes:
+      label: 📜 Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/mirrorworld-universe/oss-base-template/blob/main/CODE_OF_CONDUCT.md).
+      options:
+        - label: I agree to follow this project's [Code of Conduct](https://github.com/mirrorworld-universe/oss-base-template/blob/main/CODE_OF_CONDUCT.md).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Q&A Forum
+    url: https://github.com/mirrorworld-universe/oss-base-template/discussions/new?category=q-a
+    about: Have a question? Let us know!
+  - name: Suggestions
+    url: https://github.com/mirrorworld-universe/oss-base-template/discussions/new?category=brainstorm
+    about: Have an idea or suggestion? Let us know!

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,0 +1,48 @@
+name: Feature Request
+description: Have a feature request? Let us know!
+labels: ["enhancement", "help wanted"]
+assignees:
+  - kquirapas
+body:
+
+  # new feature request block
+  - type: checkboxes
+    id: feature-confirm-notexist
+    attributes:
+      label: Not Existing Feature Request?
+      description: Please search to see if your feature request already exist.
+      options:
+      - label: Yes, I'm sure, this is a new requested feature!
+        required: true
+
+  # not idea or suggestion block
+  - type: checkboxes
+    id: feature-confirm-notsuggestion
+    attributes:
+      label: Not an Idea or Suggestion?
+      description: |
+        Please make sure that you're submitting a request not just an idea or suggestion.
+        If this is an idea or suggestion I would recommend going [here](https://github.com/mirrorworld-universe/oss-base-template/discussions/new?category=brainstorm) first before submitting a request.
+      options:
+      - label: Yes, I'm sure, this is not idea or suggestion!
+        required: true
+
+  # details block
+  - type: textarea
+    id: feature-details
+    attributes:
+      label: Request Details
+      description: A concise description of your feature request.
+      placeholder: Add some rainbows and unicorns to it!
+    validations:
+      required: true
+
+  # terms block
+  - type: checkboxes
+    id: feature-terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/mirrorworld-universe/oss-base-template/blob/main/CODE_OF_CONDUCT.md).
+      options:
+        - label: I agree to follow this project's [Code of Conduct](https://github.com/mirrorworld-universe/oss-base-template/blob/main/CODE_OF_CONDUCT.md).
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+# Link to issue
+
+Please add a link to any relevant issues/tickets.
+
+# Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Refactor (non-breaking change that updates existing functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+- [ ] Comments have been added/updated
+
+Please delete options that are not relevant.
+
+# Test plan (required)
+
+Demonstrate the code is solid. Are changes to the templates tested in the top-level project workflows?
+
+Which commands did you test with and what are the expected results? Which tests have you added or updated? Do the
+tests cover all of the changes included in this PR?
+
+# Screenshots/Screencaps
+
+Please include screenshots that support the previous information you have provided. This would help us review your pull request better.


### PR DESCRIPTION
This commit adds the GitHub templates normally used in other repositories in this organization to this docs